### PR TITLE
[libqtsparql] Make it easier for clients to mock a driver for tests.

### DIFF
--- a/src/sparql/sparql.pro
+++ b/src/sparql/sparql.pro
@@ -18,7 +18,7 @@ install_headers.files =
 
 include($$QTSPARQL_BUILD_TREE/include/$$TARGET/headers.pri)
 
-include_headers.files = $$SYNCQT.HEADER_FILES
+include_headers.files = $$SYNCQT.HEADER_FILES $$SYNCQT.PRIVATE_HEADER_FILES
 include_headers.path = $$QTSPARQL_INSTALL_HEADERS
 INSTALLS += include_headers
 


### PR DESCRIPTION
Install private headers so the drivers can be implemented and support
for static plugins to enable the driver to be built as part of the test
binary.
